### PR TITLE
Migrate to OpenSearch with Elasticsearch v7 compatibility mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,16 @@ WORKDIR /app
 
 COPY Pipfile Pipfile
 COPY Pipfile.lock Pipfile.lock
-RUN pip install pipenv
+
+# Using the latest version of pipenv not requiring setuptools >= 67 to avoid the following runtime bug:
+#   pkg_resources._vendor.packaging.requirements.InvalidRequirement:
+#   Expected matching RIGHT_PARENTHESIS for LEFT_PARENTHESIS, after version specifier
+#   pytz (>dev)
+#   https://github.com/pypa/setuptools/issues/3889
+RUN pip install pipenv==2023.2.4
+
 RUN pipenv install --deploy --system --ignore-pipfile
 ADD . /app
-RUN pipenv install . --ignore-pipfile
+RUN pip install -e .
 
 CMD ["asclepias-broker", "shell"]

--- a/asclepias_broker/search/indexer.py
+++ b/asclepias_broker/search/indexer.py
@@ -97,7 +97,9 @@ def index_documents(docs: Iterable[dict], bulk: bool = False):
             client=current_search_client,
             actions=docs,
             index=index_name,
-            doc_type='_doc',
+            # Setting doc_type to None for OpenSearch v2 with Elasticsearch v7 compatibility mode,
+            # where the bulk URL should be `/_bulk` instead of `/_doc/_bulk`.
+            doc_type=None,
             raise_on_error=False,
             chunk_size=300,  # TODO: Make configurable
             max_chunk_bytes=(30 * 1024 * 1024),  # TODO: Make configurable

--- a/asclepias_broker/version.py
+++ b/asclepias_broker/version.py
@@ -13,4 +13,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.1.0'
+__version__ = '1.2.0.dev1'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,6 @@ services:
     extends:
       file: docker-services.yml
       service: cache
-    extends:
-      file: docker-services.yml
-      service: cache
   db:
     extends:
       file: docker-services.yml

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,28 @@ setup(
             'asclepias_broker = asclepias_broker.config',
         ],
         'invenio_base.apps': [
-            'flask_breadcrumbs = flask_breadcrumbs:Breadcrumbs',
+            # Not enabling flask-breadcrumbs to avoid the following error when starting uswgi:
+            # ERROR in app: Failed to initialize entry point: invenio_theme = invenio_theme:InvenioTheme
+            # Traceback (most recent call last):
+            #   File "/usr/local/lib/python3.8/site-packages/invenio_app/wsgi.py", line 13, in <module>
+            #     application = create_app()
+            #   File "/usr/local/lib/python3.8/site-packages/invenio_base/app.py", line 110, in _create_app
+            #     app_loader(
+            #   File "/usr/local/lib/python3.8/site-packages/invenio_base/app.py", line 173, in app_loader
+            #     _loader(app, lambda ext: ext(app), entry_points=entry_points,
+            #   File "/usr/local/lib/python3.8/site-packages/invenio_base/app.py", line 233, in _loader
+            #     init_func(ep.load())
+            #   File "/usr/local/lib/python3.8/site-packages/invenio_base/app.py", line 173, in <lambda>
+            #     _loader(app, lambda ext: ext(app), entry_points=entry_points,
+            #   File "/usr/local/lib/python3.8/site-packages/invenio_theme/ext.py", line 37, in __init__
+            #     self.init_app(app, **kwargs)
+            #   File "/usr/local/lib/python3.8/site-packages/invenio_theme/ext.py", line 47, in init_app
+            #     self.menu_ext.init_app(app)
+            #   File "/usr/local/lib/python3.8/site-packages/flask_menu/__init__.py", line 51, in init_app
+            #     raise RuntimeError("Flask application is already initialized.")
+            # RuntimeError: Flask application is already initialized.
+
+            # 'flask_breadcrumbs = flask_breadcrumbs:Breadcrumbs',
             ('asclepias_harvester = '
              'asclepias_broker.harvester.ext:AsclepiasHarvester'),
         ],


### PR DESCRIPTION
The first two commits are related to the fact that some things got broken since the last 2 years:
* `fix: docker-compose: remove duplicated extends in cache`
    Docker compose v2.28.1 fails with mapping key "extends" already defined.
* `fix: docker: pin pipenv version and use pip for setup`
    Using pip instead of pipenv since pipenv was trying to rebuild the Pipfile.lock while we just want to install the setup

The following commit might be breaking changes and should be tested:
* `fix: OpenSearch v2 with Elasticsearch v7 compatibility mode bulk URL with _doc`
    For the Zenodo instance of the citation broker, the bulk URL called was `relations.../_doc/_bulk` and it was failing. The change here makes the bulk URL called `relations.../_bulk` and fixed our issue.
* `fix: do not enable flask-breadcrumbs in invenio_base.apps to avoid flask-menu error`
    For the Zenodo instance of the citation broker, we were getting errors when starting the web API with uwsgi (the stack trace is in the code comment). Removing the entry point on the flask-breadcrumbs fixed our problem.

Release:
* `release: v1.2.0.dev1`
    We needed a version number to deploy but this could be removed from this pull request if needed.
